### PR TITLE
Add PWA build and deploy workflow

### DIFF
--- a/.github/workflows/pwa.yml
+++ b/.github/workflows/pwa.yml
@@ -1,0 +1,41 @@
+name: Build & Deploy PWA
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch: {}
+
+jobs:
+  build-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.22.0'
+
+      - name: Enable web & get packages
+        run: |
+          flutter config --enable-web
+          flutter pub get
+
+      - name: Build Flutter web (GitHub Pages path)
+        run: |
+          flutter build web --release \
+            --pwa-strategy=offline-first \
+            --base-href=/UCL2025/ \
+            --dart-define=APP_VERSION=${{ github.sha }} \
+            --dart-define=VERSION_URL=https://LuizPiccini.github.io/UCL2025/version.json
+
+      - name: Add 404 fallback (lets refresh deep links)
+        run: cp build/web/index.html build/web/404.html
+
+      - name: Create version.json
+        run: |
+          echo "{\"app\":\"ucl-fantasy\",\"version\":\"${GITHUB_SHA}\",\"apk_url\":\"https://github.com/${{ github.repository }}/releases/latest/download/app-release.apk\"}" > build/web/version.json
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./build/web


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build and deploy Flutter web PWA and publish to GitHub Pages

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0f70e8a64832186a862156ade3031