### PR TITLE
Fix PWA workflow for subdirectory Flutter project

### DIFF
--- a/.github/workflows/pwa.yml
+++ b/.github/workflows/pwa.yml
@@ -8,12 +8,15 @@ on:
 jobs:
   build-deploy:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ucl2025
     steps:
       - uses: actions/checkout@v4
 
       - uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.22.0'
+          flutter-version: '3.35.2'
 
       - name: Enable web & get packages
         run: |
@@ -38,4 +41,4 @@ jobs:
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./build/web
+          publish_dir: ./ucl2025/build/web


### PR DESCRIPTION
## Summary
- ensure GitHub Actions runs Flutter commands from `ucl2025`
- deploy built web app from subdirectory to GitHub Pages
- pin workflow to Flutter 3.35 for Dart 3.9 compatibility

## Testing
- `flutter --version`
- `flutter test`


------
https://chatgpt.com/codex/tasks/task_e_68b0fa8e19fc8321badae7a86d323dfa